### PR TITLE
Refactor proposal status handling

### DIFF
--- a/src/app/proposals/[id]/page.tsx
+++ b/src/app/proposals/[id]/page.tsx
@@ -8,6 +8,7 @@ import ProposalDetails from "@/components/proposals/ProposalDetails";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { getStatusConfig } from "@/helpers/proposal-status";
 import { useVotingStatus } from "@/components/proposals/TimeStatus";
 import { safeNumberFromBigInt, safeString } from "@/helpers/proposal-utils";
 import { format } from "date-fns";
@@ -50,32 +51,14 @@ export default function ProposalDetailsPage() {
 
   const getStatusBadge = () => {
     if (!proposal) return null;
-    
-    if (isActive) {
-      return (
-        <Badge className="bg-primary/20 text-primary hover:bg-primary/30 border-primary/50 transition-colors duration-150">
-          Active
-        </Badge>
-      );
-    } else if (isEnded && proposal.passed) {
-      return (
-        <Badge className="bg-green-500/20 text-green-500 hover:bg-green-500/30 border-green-500/50 transition-colors duration-150">
-          Passed
-        </Badge>
-      );
-    } else if (isEnded && !proposal.passed) {
-      return (
-        <Badge className="bg-destructive/20 text-destructive hover:bg-destructive/30 border-destructive/50 transition-colors duration-150">
-          Failed
-        </Badge>
-      );
-    } else {
-      return (
-        <Badge className="bg-muted/50 text-muted-foreground hover:bg-muted/70 border-muted transition-colors duration-150">
-          Pending
-        </Badge>
-      );
-    }
+    const status = getStatusConfig(isActive, isEnded, proposal.passed);
+    return (
+      <Badge
+        className={`${status.bg} ${status.color} ${status.border} transition-colors duration-150`}
+      >
+        {status.label}
+      </Badge>
+    );
   };
 
   if (loading) {

--- a/src/components/proposals/ProposalCard.tsx
+++ b/src/components/proposals/ProposalCard.tsx
@@ -5,11 +5,9 @@ import {
   Clock,
   User,
   BarChart3,
-  CheckCircle,
-  XCircle,
-  AlertCircle,
   Building2,
 } from "lucide-react";
+import { getStatusConfig } from "@/helpers/proposal-status";
 import { useVotingStatus } from "./TimeStatus";
 import type { Proposal, ProposalWithDAO } from "@/types/supabase";
 import { format } from "date-fns";
@@ -39,43 +37,7 @@ export default function ProposalCard({
     safeNumberFromBigInt(proposal.vote_end)
   );
 
-  const getStatusConfig = () => {
-    if (isActive) {
-      return {
-        icon: BarChart3,
-        color: "text-primary",
-        bg: "bg-primary/10",
-        border: "border-primary/20",
-        label: "Active",
-      };
-    } else if (isEnded && proposal.passed) {
-      return {
-        icon: CheckCircle,
-        color: "text-green-500",
-        bg: "bg-green-500/10",
-        border: "border-green-500/20",
-        label: "Passed",
-      };
-    } else if (isEnded && !proposal.passed) {
-      return {
-        icon: XCircle,
-        color: "text-red-500",
-        bg: "bg-red-500/10",
-        border: "border-red-500/20",
-        label: "Failed",
-      };
-    } else {
-      return {
-        icon: AlertCircle,
-        color: "text-muted-foreground",
-        bg: "bg-muted/10",
-        border: "border-muted/20",
-        label: "Pending",
-      };
-    }
-  };
-
-  const statusConfig = getStatusConfig();
+  const statusConfig = getStatusConfig(isActive, isEnded, proposal.passed);
   const StatusIcon = statusConfig.icon;
 
   const formatNumber = (num: number) => {

--- a/src/helpers/proposal-status.ts
+++ b/src/helpers/proposal-status.ts
@@ -1,0 +1,62 @@
+export const PROPOSAL_STATUSES = [
+  "created", // until we confirm the TX is mined
+  "voting_delay", // after proposal is created, but before voting starts
+  "voting_active", // when voting is open
+  "veto_period", // also an execution delay
+  "executable", // not concluded but can be executed
+  "expired", // not concluded but cannot be executed anymore
+  "concluded", // proposal is concluded, final state
+] as const;
+
+export type ProposalStatus = typeof PROPOSAL_STATUSES[number];
+
+import { LucideIcon, BarChart3, CheckCircle, XCircle, AlertCircle } from "lucide-react";
+
+export interface StatusConfig {
+  icon: LucideIcon;
+  color: string;
+  bg: string;
+  border: string;
+  label: string;
+}
+
+export function getStatusConfig(
+  isActive: boolean,
+  isEnded: boolean,
+  passed: boolean,
+): StatusConfig {
+  if (isActive) {
+    return {
+      icon: BarChart3,
+      color: "text-primary",
+      bg: "bg-primary/10",
+      border: "border-primary/20",
+      label: "Active",
+    };
+  }
+  if (isEnded && passed) {
+    return {
+      icon: CheckCircle,
+      color: "text-green-500",
+      bg: "bg-green-500/10",
+      border: "border-green-500/20",
+      label: "Passed",
+    };
+  }
+  if (isEnded && !passed) {
+    return {
+      icon: XCircle,
+      color: "text-red-500",
+      bg: "bg-red-500/10",
+      border: "border-red-500/20",
+      label: "Failed",
+    };
+  }
+  return {
+    icon: AlertCircle,
+    color: "text-muted-foreground",
+    bg: "bg-muted/10",
+    border: "border-muted/20",
+    label: "Pending",
+  };
+}


### PR DESCRIPTION
## Summary
- centralize proposal status values and display logic
- use new `getStatusConfig` helper in `ProposalCard` and details page

## Testing
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68494691c9648323ac447ce798f4573a